### PR TITLE
fix: handle null expected data

### DIFF
--- a/packages/gqltest/gqltest.js
+++ b/packages/gqltest/gqltest.js
@@ -146,6 +146,7 @@ function assertExpected(response, expected, label) {
     if (Object.hasOwn(expected, "errors")) {
       // Since data exists this must be a valid GraphQL response with 200
       chai.expect(response.response.status).to.equal(200);
+      chai.assert.property(response.body, "data")
       // chai.assert.graphQL expects no errors so remove errors from body
       if (expected.data != null) {
         chai.assert.graphQL(
@@ -153,7 +154,6 @@ function assertExpected(response, expected, label) {
           expected.data,
         );
       } else {
-        chai.assert.property(response.body, "data")
         chai.assert.isNull(response.body.data)
       }
       expectFieldErrors(response.body, expected.errors);


### PR DESCRIPTION
Ensures that an expected result with `data:null` is handled.

Such as:
```
  {
    "name": "qnn",
    "query": "{qnn}",
    "expected": {
      "data": null,
      "errors": [
        {
          "message": "Cannot return null for non-nullable field Query.qnn.",
          "locations": [{"line": 4, "column": 2}],
          "path": ["qnn"]
        }
      ]
    }
  },
```