### PR TITLE
chore: add extended introspection apic-graphql tests

### DIFF
--- a/packages/gqltest/gqltest.js
+++ b/packages/gqltest/gqltest.js
@@ -141,8 +141,8 @@ async function execute({
 //  - use approach (2)
 //  - use aliases in request: {d:data e:errors}
 function assertExpected(response, expected, label) {
-  expected = optionalJSONFromFile(expected);
-  
+  expected = optionalJSONFromFile(expected, label);
+
   // (2),(3) - Response at the root.
   if (Object.hasOwn(expected, "data")) {
     if (Object.hasOwn(expected, "errors")) {

--- a/packages/gqltest/gqltest.js
+++ b/packages/gqltest/gqltest.js
@@ -141,6 +141,8 @@ async function execute({
 //  - use approach (2)
 //  - use aliases in request: {d:data e:errors}
 function assertExpected(response, expected, label) {
+  expected = optionalJSONFromFile(expected);
+  
   // (2),(3) - Response at the root.
   if (Object.hasOwn(expected, "data")) {
     if (Object.hasOwn(expected, "errors")) {

--- a/packages/gqltest/stepzen.js
+++ b/packages/gqltest/stepzen.js
@@ -68,7 +68,7 @@ const introspectionTests = [
 
 // runIntrospectionTests runs standard gqltest and stepzen introspectionTests.
 function runIntrospectionTests(endpoint, headers) {
-  runtests("introspection", endpoint, stepzen.regular(), gqlintrospectionTests);
+  runtests("introspection", endpoint, headers, gqlintrospectionTests);
   runtests(
     "introspection-apic-graphql",
     endpoint,

--- a/packages/gqltest/stepzen.js
+++ b/packages/gqltest/stepzen.js
@@ -72,7 +72,7 @@ function runIntrospectionTests(endpoint, headers) {
   runtests(
     "introspection-apic-graphql",
     endpoint,
-    stepzen.regular(),
+    headers,
     introspectionTests,
   );
 }

--- a/packages/gqltest/stepzen.js
+++ b/packages/gqltest/stepzen.js
@@ -1,18 +1,26 @@
 const { execSync } = require("child_process");
-
-const { GQLHeaders } = require("./gqltest.js");
+const graphql = require("graphql");
+const {
+  GQLHeaders,
+  runtests,
+  instrospectionTests: gqlIntrospectionTests,
+} = require("./gqltest.js");
 
 // assumption is that when testing against a StepZen instance the user is logged in.
 // For CI-CD see https://github.com/stepzen-dev/stepzen-login
 
 // Returns GQLHeaders using the admin key.
 function admin() {
-  return new GQLHeaders().withAPIKey(execSync(`stepzen whoami --adminkey`).toString().trim());
+  return new GQLHeaders().withAPIKey(
+    execSync(`stepzen whoami --adminkey`).toString().trim(),
+  );
 }
 
 // Returns GQLHeaders using the apikey key.
 function regular() {
-  return new GQLHeaders().withAPIKey(execSync(`stepzen whoami --apikey`).toString().trim());
+  return new GQLHeaders().withAPIKey(
+    execSync(`stepzen whoami --apikey`).toString().trim(),
+  );
 }
 
 // Returns GQLHeaders using the no authorization.
@@ -22,21 +30,56 @@ function public() {
 
 // Returns GQLHeaders using the access token key.
 function token() {
-  return new GQLHeaders().withToken(execSync(`stepzen whoami --accesstoken`).toString().trim());
+  return new GQLHeaders().withToken(
+    execSync(`stepzen whoami --accesstoken`).toString().trim(),
+  );
 }
 
 // introspection tests is a collection of tests ensuring that introspection capabilities work.
 // The requests are invoked but no expected data.
+// The returned set should be tested in addition to gqltest.introspectionTests
+// and can be doen using stepzen.runIntrospectionTests.
 const introspectionTests = [
   {
     // By default StepZen endpoints are setup for Apollo Federation.
-    label: 'federation-service',
-    query: '{_service { sdl }}',
+    label: "federation-service",
+    query: "{_service { sdl }}",
   },
-]
+  {
+    // Introspection operation with October 2021 additions
+    label: "introspection-october-2021",
+    query: graphql.getIntrospectionQuery({
+      specifiedByUrl: true,
+      directiveIsRepeatable: true,
+      schemaDescription: true,
+    }),
+  },
+  {
+    // Introspection operation with all StepZen's currently supported capabilities
+    label: "introspection-current",
+    query: graphql.getIntrospectionQuery({
+      specifiedByUrl: true,
+      directiveIsRepeatable: true,
+      schemaDescription: true,
+      inputValueDeprecation: true,
+    }),
+  },
+];
+
+// runIntrospectionTests runs standard gqltest and stepzen introspectionTests.
+function runIntrospectionTests(endpoint, headers) {
+  runtests("introspection", endpoint, stepzen.regular(), gqlintrospectionTests);
+  runtests(
+    "introspection-apic-graphql",
+    endpoint,
+    stepzen.regular(),
+    introspectionTests,
+  );
+}
 
 exports.admin = admin;
 exports.public = public;
 exports.regular = regular;
 exports.token = token;
 exports.introspectionTests = introspectionTests;
+exports.runIntrospectionTests = runIntrospectionTests;

--- a/packages/gqltest/stepzen.js
+++ b/packages/gqltest/stepzen.js
@@ -68,7 +68,7 @@ const introspectionTests = [
 
 // runIntrospectionTests runs standard gqltest and stepzen introspectionTests.
 function runIntrospectionTests(endpoint, headers) {
-  runtests("introspection", endpoint, headers, gqlintrospectionTests);
+  runtests("introspection", endpoint, headers, gqlIntrospectionTests);
   runtests(
     "introspection-apic-graphql",
     endpoint,


### PR DESCRIPTION
adds extended introspection requests for APIC-Graphql and a utility method to run them.

Fixed the error loading an expected value from a file.